### PR TITLE
请升级com.fasterxml.jackson.dataformat:jackson-dataformat-cbor组件版本以解决1个安全漏洞

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -53,7 +53,7 @@
         <dependency>
             <groupId>com.amazonaws</groupId>
             <artifactId>aws-java-sdk</artifactId>
-            <version>1.11.412</version>
+            <version>1.12.174</version>
         </dependency>
 
         <dependency>


### PR DESCRIPTION
将 **com.amazonaws:aws-java-sdk** 组件从1.11.412 版本升级至 1.12.174版本,
用于修复以下安全漏洞：


序号 | 漏洞编号 | 漏洞标题 | 漏洞级别
-- | -- | -- | --
1 | [MPS-2021-1998](https://www.oscs1024.com/hd/MPS-2021-1998) | FasterXML jackson-dataformat-cbor 内存耗尽漏洞 | 高危
  |   |   |   


<br/>

_注意 ：此 PR 由您（或拥有此仓库权限的其他维护者）授权 [墨菲安全](https://www.murphysec.com) 打开_

了解更多：
- [如何快速修复代码安全问题](https://www.murphysec.com/docs/faqs/security-issues/how-to-quick-fixes.html)
